### PR TITLE
Remove references to Eli's GH username

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @joelvdavies @leandro-liborio @patrick-austin @elichad @stur86
+* @joelvdavies @leandro-liborio @patrick-austin

--- a/README.md
+++ b/README.md
@@ -143,6 +143,6 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
-* [@elichad](https://github.com/elichad/)
-* [@stur86](https://github.com/stur86/)
+* [@leandro-liborio](https://github.com/leandro-liborio/)
+* [@patrick-austin](https://github.com/patrick-austin/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -65,5 +65,3 @@ extra:
     - joelvdavies
     - leandro-liborio
     - patrick-austin
-    - elichad
-    - stur86


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Removes Eli as in https://github.com/conda-forge/muspinsim-feedstock/pull/22. Also does same for stur86.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
